### PR TITLE
Google Search: support "search_type" parameter, and allow setting custom parameters in future

### DIFF
--- a/src/LaravelScrapingBeeGoogleSearch.php
+++ b/src/LaravelScrapingBeeGoogleSearch.php
@@ -56,6 +56,16 @@ final class LaravelScrapingBeeGoogleSearch
     }
 
     /**
+     * https://www.scrapingbee.com/documentation/google/#search_type
+     */
+    public function searchType(string $type): self
+    {
+        $this->params['search_type'] = $type;
+
+        return $this;
+    }
+
+    /**
      * https://www.scrapingbee.com/documentation/google/#country_code
      */
     public function countryCode(string $countryCode): self
@@ -111,6 +121,17 @@ final class LaravelScrapingBeeGoogleSearch
     public function addHtml(): self
     {
         $this->params['add_html'] = true;
+
+        return $this;
+    }
+
+    /*
+     * If the API hasn't caught up and you need to support a new ScrapingBee parameter,
+     * you can set it using this method.
+     */
+    public function setParam(string $key, mixed $value): self
+    {
+        $this->params[$key] = $value;
 
         return $this;
     }


### PR DESCRIPTION
I've added a method to support the [search_type parameter](https://www.scrapingbee.com/documentation/google/#search_type) when using the Google Search class. This allows users to override the default "`classic`" results, and search for `news` or `maps` instead.

As the class was marked `final`, I've copied over the `setParam` method from the main class too.

Thanks for a great package! 🙏